### PR TITLE
Adding check to api call

### DIFF
--- a/app/src/main/java/com/example/gamestache/Converters.kt
+++ b/app/src/main/java/com/example/gamestache/Converters.kt
@@ -4,6 +4,9 @@ import androidx.room.TypeConverter
 import com.example.gamestache.models.individual_game.*
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneOffset
 
 class Converters {
 
@@ -127,6 +130,16 @@ class Converters {
     @TypeConverter
     fun multiplayerModesListToString(multiplayerModesObject: List<MultiplayerModesItem?>?): String?{
         return Gson().toJson(multiplayerModesObject)
+    }
+
+    @TypeConverter
+    fun fromTimestamp(value: Long?): LocalDateTime? {
+        return value?.let { LocalDateTime.ofInstant(Instant.ofEpochMilli(value), ZoneOffset.UTC) }
+    }
+
+    @TypeConverter
+    fun dateToTimestamp(date: LocalDateTime?): Long? {
+        return date?.atZone(ZoneOffset.UTC)?.toInstant()?.toEpochMilli()
     }
 
 }

--- a/app/src/main/java/com/example/gamestache/koin/KoinModule.kt
+++ b/app/src/main/java/com/example/gamestache/koin/KoinModule.kt
@@ -74,21 +74,26 @@ val gameStacheDatabaseModule = module {
         return database.individualGameDao()
     }
 
+    fun provideTwitchAuthorizationDao(database: GameStacheDatabase): TwitchAuthorizationDao {
+        return database.twitchAuthDao()
+    }
+
     single { provideGameStacheDatabase(androidApplication()) }
     single { providePlatformSpinnerDao(get()) }
     single { provideGenreSpinnerDao(get()) }
     single { provideGameModeSpinnerDao(get()) }
     single { provideIndividualGameDataDao(get()) }
+    single { provideTwitchAuthorizationDao(get()) }
 
 }
 
 val gameStacheRepositoryModule = module {
 
-    fun provideGameStacheRepository(twitchApi: TwitchApi, authApi: TwitchApiAuth, individualGameDao: IndividualGameDao, platformsSpinnerDao: PlatformSpinnerDao, genresSpinnerDao: GenresSpinnerDao, gameModesSpinnerDao: GameModesSpinnerDao): GameStacheRepository {
-        return GameStacheRepository(twitchApi, authApi, individualGameDao, platformsSpinnerDao, genresSpinnerDao, gameModesSpinnerDao)
+    fun provideGameStacheRepository(twitchApi: TwitchApi, authApi: TwitchApiAuth, individualGameDao: IndividualGameDao, platformsSpinnerDao: PlatformSpinnerDao, genresSpinnerDao: GenresSpinnerDao, gameModesSpinnerDao: GameModesSpinnerDao, twitchAuthorizationDao: TwitchAuthorizationDao): GameStacheRepository {
+        return GameStacheRepository(twitchApi, authApi, individualGameDao, platformsSpinnerDao, genresSpinnerDao, gameModesSpinnerDao, twitchAuthorizationDao)
     }
 
-    single { provideGameStacheRepository(get(), get(), get(), get(), get(), get()) }
+    single { provideGameStacheRepository(get(), get(), get(), get(), get(), get(), get()) }
 }
 
 

--- a/app/src/main/java/com/example/gamestache/models/TwitchAuthorization.kt
+++ b/app/src/main/java/com/example/gamestache/models/TwitchAuthorization.kt
@@ -1,3 +1,14 @@
 package com.example.gamestache.models
 
-data class TwitchAuthorization(val access_token: String, val expires_in: Int, val token_type: String)
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import java.time.LocalDateTime
+
+@Entity(tableName = "auth_table")
+data class TwitchAuthorization(
+    @PrimaryKey(autoGenerate = false)
+    val token_type: String,
+    val access_token: String,
+    val expires_in: Int,
+    var token_birth_date: LocalDateTime
+    )

--- a/app/src/main/java/com/example/gamestache/repository/GameStacheRepository.kt
+++ b/app/src/main/java/com/example/gamestache/repository/GameStacheRepository.kt
@@ -1,29 +1,35 @@
 package com.example.gamestache.repository
 
+import android.util.Log
 import androidx.lifecycle.LiveData
 import com.example.gamestache.Constants.Companion.CLIENT_ID
 import com.example.gamestache.Constants.Companion.CLIENT_SECRET
 import com.example.gamestache.Constants.Companion.GRANT_TYPE
-import com.example.gamestache.room.GameModesSpinnerDao
-import com.example.gamestache.room.GenresSpinnerDao
-import com.example.gamestache.room.PlatformSpinnerDao
 import com.example.gamestache.api.TwitchApi
 import com.example.gamestache.api.TwitchApiAuth
 import com.example.gamestache.models.*
 import com.example.gamestache.models.explore_spinners.*
 import com.example.gamestache.models.individual_game.IndividualGameDataItem
 import com.example.gamestache.models.search_results.SearchResultsResponse
-import com.example.gamestache.room.IndividualGameDao
+import com.example.gamestache.room.*
 import okhttp3.RequestBody
 import retrofit2.Response
+import java.time.LocalDate
+import java.time.LocalDateTime
 
-class GameStacheRepository(private val api: TwitchApi, private val authApi: TwitchApiAuth, private val individualGameDao: IndividualGameDao, private val platformsResponseDao: PlatformSpinnerDao, private val genresResponseDao: GenresSpinnerDao, private val gameModesResponseDao: GameModesSpinnerDao){
+class GameStacheRepository(
+    private val api: TwitchApi, private val authApi: TwitchApiAuth, private val individualGameDao: IndividualGameDao,
+    private val platformsResponseDao: PlatformSpinnerDao, private val genresResponseDao: GenresSpinnerDao,
+    private val gameModesResponseDao: GameModesSpinnerDao, private val twitchAuthorizationDao: TwitchAuthorizationDao
+    ) {
 
     fun getPlatformsListFromDb(): LiveData<List<GenericSpinnerItem>> = platformsResponseDao.getPlatformsListFromDb()
     fun getGenresListFromDb(): LiveData<List<GenericSpinnerItem>> = genresResponseDao.getGenresListFromDb()
     fun getGameModesListFromDb(): LiveData<List<GenericSpinnerItem>> = gameModesResponseDao.getGameModesListFromDb()
     fun checkIfGameIsInDb(gameID: Int): LiveData<Int> = individualGameDao.checkIfGameExistsInRoom(gameID)
     fun getIndividualGameDataFromDb(gameID: Int): LiveData<List<IndividualGameDataItem?>> = individualGameDao.getIndividualGameDataFromRoom(gameID)
+    private fun getTwitchAuthFromDb(): TwitchAuthorization = twitchAuthorizationDao.getTwitchAuthFromDb()
+    private fun getAuthStatusInDb(): Int = twitchAuthorizationDao.checkIfAuthTokenIsInDB()
 
      suspend fun storePlatformsListToDb(spinnerResponseItem: PlatformsResponseItem) {
         platformsResponseDao.addPlatformsListToDb(spinnerResponseItem)
@@ -41,8 +47,44 @@ class GameStacheRepository(private val api: TwitchApi, private val authApi: Twit
         individualGameDao.storeIndividualGameDataInRoom(individualGameData)
     }
 
-     suspend fun getAccessToken(): Response<TwitchAuthorization> {
-        return authApi.getAccessToken(CLIENT_ID, CLIENT_SECRET, GRANT_TYPE)
+    private suspend fun storeTwitchAuthInDb(twitchAuthorization: TwitchAuthorization) {
+        twitchAuthorizationDao.addTwitchAuthToDb(twitchAuthorization)
+    }
+
+    private suspend fun getNewAuthToken(): TwitchAuthorization? {
+        val twitchAuth = authApi.getAccessToken(CLIENT_ID, CLIENT_SECRET, GRANT_TYPE)
+
+        if (twitchAuth.isSuccessful) {
+            twitchAuth.body()?.token_birth_date = LocalDateTime.now()
+            twitchAuth.body()?.let { storeTwitchAuthInDb(it) }
+            return twitchAuth.body()
+        } else {
+            //TODO: am i doing the Log.i correctly
+            Log.i("GameStacheRepository - getAccessToken()", twitchAuth.toString())
+            return null
+        }
+    }
+
+    private fun determineTokenExpirationDate(authToken: TwitchAuthorization): LocalDateTime {
+        val authTokenBirthDate = authToken.token_birth_date
+        return authTokenBirthDate.plusDays(DAYS_TO_GET_EXPIRATION)
+    }
+
+    suspend fun getAuthToken(): TwitchAuthorization? {
+        val authStatusInDb = getAuthStatusInDb()
+
+        if (authStatusInDb == AUTH_NOT_IN_DB) {
+            return getNewAuthToken()
+        } else {
+            val authToken = getTwitchAuthFromDb()
+            val tokenExpirationDate = determineTokenExpirationDate(authToken)
+
+            if (LocalDateTime.now().isAfter(tokenExpirationDate)) {
+                return getNewAuthToken()
+            } else {
+                return authToken
+            }
+        }
     }
 
      suspend fun searchGames(accessToken: String, gamesSearch: RequestBody): Response<SearchResultsResponse> {
@@ -64,6 +106,11 @@ class GameStacheRepository(private val api: TwitchApi, private val authApi: Twit
 
     suspend fun getIndividualGameData(accessToken: String, individualGameSearch: RequestBody): Response<List<IndividualGameDataItem>> {
         return api.getIndividualGameData("Bearer $accessToken", individualGameSearch)
+    }
+
+    companion object {
+        const val AUTH_NOT_IN_DB = 0
+        const val DAYS_TO_GET_EXPIRATION: Long = 30
     }
 
 }

--- a/app/src/main/java/com/example/gamestache/room/GameStacheDatabase.kt
+++ b/app/src/main/java/com/example/gamestache/room/GameStacheDatabase.kt
@@ -6,12 +6,19 @@ import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 import com.example.gamestache.Converters
+import com.example.gamestache.models.TwitchAuthorization
 import com.example.gamestache.models.individual_game.IndividualGameDataItem
 import com.example.gamestache.models.explore_spinners.GameModesResponseItem
 import com.example.gamestache.models.explore_spinners.GenresResponseItem
 import com.example.gamestache.models.explore_spinners.PlatformsResponseItem
 
-@Database(entities = [PlatformsResponseItem::class, GenresResponseItem::class, GameModesResponseItem::class, IndividualGameDataItem::class], version = 1, exportSchema = false)
+@Database(entities =
+[PlatformsResponseItem::class,
+    GenresResponseItem::class,
+    GameModesResponseItem::class,
+    IndividualGameDataItem::class,
+    TwitchAuthorization::class
+], version = 1, exportSchema = false)
 @TypeConverters( Converters::class )
 abstract class GameStacheDatabase: RoomDatabase() {
 
@@ -19,6 +26,7 @@ abstract class GameStacheDatabase: RoomDatabase() {
     abstract fun genresSpinnerDao(): GenresSpinnerDao
     abstract fun gameModesSpinnerDao(): GameModesSpinnerDao
     abstract fun individualGameDao(): IndividualGameDao
+    abstract fun twitchAuthDao(): TwitchAuthorizationDao
 
     companion object{
         @Volatile

--- a/app/src/main/java/com/example/gamestache/room/TwitchAuthorizationDao.kt
+++ b/app/src/main/java/com/example/gamestache/room/TwitchAuthorizationDao.kt
@@ -1,0 +1,19 @@
+package com.example.gamestache.room
+
+import androidx.room.*
+import com.example.gamestache.models.TwitchAuthorization
+
+@Dao
+interface TwitchAuthorizationDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun addTwitchAuthToDb(twitchAuthorization: TwitchAuthorization)
+
+    @Transaction
+    @Query("SELECT * FROM auth_table")
+    fun getTwitchAuthFromDb(): TwitchAuthorization
+
+    @Transaction
+    @Query("SELECT COUNT(*) FROM auth_table")
+    fun checkIfAuthTokenIsInDB(): Int
+
+}

--- a/app/src/main/java/com/example/gamestache/ui/explore/ExploreFragment.kt
+++ b/app/src/main/java/com/example/gamestache/ui/explore/ExploreFragment.kt
@@ -2,13 +2,16 @@ package com.example.gamestache.ui.explore
 
 import android.app.Dialog
 import android.content.Context
+import android.content.res.Resources
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputMethodManager
-import android.widget.*
+import android.widget.AdapterView
+import android.widget.Spinner
+import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -20,7 +23,6 @@ import com.example.gamestache.models.explore_spinners.GameModesResponseItem
 import com.example.gamestache.models.explore_spinners.GenericSpinnerItem
 import com.example.gamestache.models.explore_spinners.GenresResponseItem
 import com.example.gamestache.models.explore_spinners.PlatformsResponseItem
-import kotlinx.android.synthetic.main.fragment_explore.*
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
@@ -59,7 +61,7 @@ class ExploreFragment : Fragment() {
             adapter = exploreAdapter
             addItemDecoration(DividerItemDecoration(requireContext(), RecyclerView.VERTICAL))
         }
-        exploreViewModel.getAccessToken()
+        exploreViewModel.getAuthToken()
 
         //TODO: HOW TO PERSIST STATE OF SPINNER SELECTION AFTER NAVIGATING BACK FROM INDIVIDUAL GAME FRAGMENT
         //TODO WALK THROUGH WITH KEVIN WHAT I DID WITH INITSPINNERS AND SETSPINNERONCLICK TO SEE IF THIS IS THE BEST WAY OF DOING IT
@@ -181,6 +183,9 @@ class ExploreFragment : Fragment() {
 
         exploreViewModel.twitchAuthorization.value?.access_token?.let { twitchAccessToken ->
             exploreViewModel.searchGames(twitchAccessToken, searchRequestBody)
+        } ?: run {
+            exploreViewModel.getAuthToken()
+            makeSearchAgainToast(requireContext(), resources).show()
         }
 
     }
@@ -231,6 +236,7 @@ class ExploreFragment : Fragment() {
         const val PLATFORM_SPINNER_PROMPT = "Select a platform"
         const val GENRE_SPINNER_PROMPT = "Select a genre"
         const val GAME_MODES_SPINNER_PROMPT = "Select multiplayer capabilities"
+        fun makeSearchAgainToast(context: Context, resources: Resources): Toast = Toast.makeText(context, resources.getString(R.string.tried_searching_with_null_twitch_auth), Toast.LENGTH_SHORT)
     }
 
     enum class ExploreSpinners(val spinnerName: String) {

--- a/app/src/main/java/com/example/gamestache/ui/individual_game/IndividualGameFragment.kt
+++ b/app/src/main/java/com/example/gamestache/ui/individual_game/IndividualGameFragment.kt
@@ -68,7 +68,7 @@ class IndividualGameFragment : Fragment() {
             if (progressBarStatus) {
                 loadingDialog.show()
             } else {
-                object : CountDownTimer(500, 500) {
+                object : CountDownTimer(COUNTDOWN_TIMER_DELAY, COUNTDOWN_TIMER_INTERVAL) {
                     override fun onFinish() {
                         loadingDialog.dismiss()
                     }
@@ -314,6 +314,8 @@ class IndividualGameFragment : Fragment() {
         const val SIMILAR_GAME_TOP_PADDING = 3
         const val SIMILAR_GAME_RIGHT_PADDING = 17
         const val SIMILAR_GAME_BOTTOM_PADDING = 3
+        const val COUNTDOWN_TIMER_DELAY: Long = 500
+        const val COUNTDOWN_TIMER_INTERVAL: Long = 500
 
     }
 }

--- a/app/src/main/java/com/example/gamestache/ui/individual_game/IndividualGameFragment.kt
+++ b/app/src/main/java/com/example/gamestache/ui/individual_game/IndividualGameFragment.kt
@@ -3,7 +3,6 @@ package com.example.gamestache.ui.individual_game
 import android.app.Dialog
 import android.os.Bundle
 import android.os.CountDownTimer
-import android.os.Handler
 import android.view.LayoutInflater
 import android.view.View
 import android.view.View.GONE
@@ -42,8 +41,6 @@ class IndividualGameFragment : Fragment() {
 
         binding.individualgameviewmodel = individualGameViewModel
         binding.lifecycleOwner = this
-
-
 
         return binding.root
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,5 +54,6 @@
     <string name="original_release_date">Original Release Date: %1$s</string>
     <string name="similar_game">\u0009-\u0020%1$s</string>
     <string name="blank_search_attempt_error_message">You must enter a game or select one option from a spinner</string>
+    <string name="tried_searching_with_null_twitch_auth">Unable to access the database. Try searching again</string>
 
 </resources>


### PR DESCRIPTION
The app now caches the authentication token needed to make api calls. Instead of generating a new one every time it needs one, it now checks to see if there is one in the cache, and if the token is too old or not. If one doesn't exist or it is too old, the app will grab a new token and store that in Room. 