### PR TITLE
Persisting Spinner Selection On Explore Screen

### DIFF
--- a/app/src/main/java/com/example/gamestache/ui/explore/ExploreFragment.kt
+++ b/app/src/main/java/com/example/gamestache/ui/explore/ExploreFragment.kt
@@ -59,22 +59,23 @@ class ExploreFragment : Fragment() {
         }
         exploreViewModel.getAuthToken()
 
-        //TODO: HOW TO PERSIST STATE OF SPINNER SELECTION AFTER NAVIGATING BACK FROM INDIVIDUAL GAME FRAGMENT
         exploreViewModel.currentPlatformListInDb.observe(viewLifecycleOwner, { spinnerListFromRoom ->
-            if (spinnerListFromRoom != null) { platformSpinner = platformSpinner?.let { initSpinners(it, spinnerListFromRoom, PLATFORM_SPINNER_PROMPT) }
-                    platformSpinner?.let { setSpinnerOnClick(it, "platform", savedInstanceState) }
-                }
-            })
+            platformSpinner = platformSpinner?.let { initSpinners(it, spinnerListFromRoom, PLATFORM_SPINNER_PROMPT) }
+            platformSpinner?.let { setSpinnerOnClick(it, "platform") }
+            platformSpinner?.setSelection(exploreViewModel.platformSpinnerSelection)
+        })
 
         exploreViewModel.currentGenreListInDb.observe(viewLifecycleOwner, { spinnerListFromRoom ->
             genreSpinner = genreSpinner?.let { initSpinners(it, spinnerListFromRoom, GENRE_SPINNER_PROMPT) }
-            genreSpinner?.let { setSpinnerOnClick(it, "genre", savedInstanceState) }
+            genreSpinner?.let { setSpinnerOnClick(it, "genre") }
+            genreSpinner?.setSelection(exploreViewModel.genreSpinnerSelection)
         })
 
         exploreViewModel.currentGameModesListInDb.observe(viewLifecycleOwner, { spinnerListFromRoom ->
-                gameModesSpinner = gameModesSpinner?.let { initSpinners(it, spinnerListFromRoom, GAME_MODES_SPINNER_PROMPT) }
-                gameModesSpinner?.let { setSpinnerOnClick(it, "gameMode", savedInstanceState) }
-            })
+            gameModesSpinner = gameModesSpinner?.let { initSpinners(it, spinnerListFromRoom, GAME_MODES_SPINNER_PROMPT) }
+            gameModesSpinner?.let { setSpinnerOnClick(it, "gameMode") }
+            gameModesSpinner?.setSelection(exploreViewModel.gameModesSpinnerSelection)
+        })
 
         exploreViewModel.searchText().observe(viewLifecycleOwner, { text ->
             searchRequestBody = text
@@ -175,13 +176,22 @@ class ExploreFragment : Fragment() {
 
     }
 
-    private fun setSpinnerOnClick(spinner: Spinner, spinnerName: String, savedInstanceState: Bundle?) {
+    private fun setSpinnerOnClick(spinner: Spinner, spinnerName: String) {
         spinner.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
             override fun onItemSelected(adapterView: AdapterView<*>?, view: View?, itemPosition: Int, rowId: Long) {
                 when (spinnerName) {
-                    ExploreSpinners.PLATFORM_SPINNER.spinnerName -> binding.btnClearPlatformSpinner.visibility = exploreViewModel.setExploreSpinnersClearButtonVisibility(itemPosition)
-                    ExploreSpinners.GENRE_SPINNER.spinnerName -> binding.btnClearGenreSpinner.visibility = exploreViewModel.setExploreSpinnersClearButtonVisibility(itemPosition)
-                    ExploreSpinners.GAME_MODE_SPINNER.spinnerName -> binding.btnClearMultiplayerSpinner.visibility = exploreViewModel.setExploreSpinnersClearButtonVisibility(itemPosition)
+                    ExploreSpinners.PLATFORM_SPINNER.spinnerName -> {
+                        binding.btnClearPlatformSpinner.visibility = exploreViewModel.setExploreSpinnersClearButtonVisibility(itemPosition)
+                        exploreViewModel.platformSpinnerSelection = itemPosition
+                    }
+                    ExploreSpinners.GENRE_SPINNER.spinnerName -> {
+                        binding.btnClearGenreSpinner.visibility = exploreViewModel.setExploreSpinnersClearButtonVisibility(itemPosition)
+                        exploreViewModel.genreSpinnerSelection = itemPosition
+                    }
+                    ExploreSpinners.GAME_MODE_SPINNER.spinnerName -> {
+                        binding.btnClearMultiplayerSpinner.visibility = exploreViewModel.setExploreSpinnersClearButtonVisibility(itemPosition)
+                        exploreViewModel.gameModesSpinnerSelection = itemPosition
+                    }
                 }
                 if (itemPosition == 0) {
                     when (spinnerName) {

--- a/app/src/main/java/com/example/gamestache/ui/explore/ExploreViewModel.kt
+++ b/app/src/main/java/com/example/gamestache/ui/explore/ExploreViewModel.kt
@@ -36,6 +36,10 @@ class ExploreViewModel(private val gameStacheRepo: GameStacheRepository) : ViewM
     val currentGenreListInDb: LiveData<List<GenericSpinnerItem>> = gameStacheRepo.getGenresListFromDb()
     val currentGameModesListInDb: LiveData<List<GenericSpinnerItem>> = gameStacheRepo.getGameModesListFromDb()
 
+    var platformSpinnerSelection = 0
+    var genreSpinnerSelection = 0
+    var gameModesSpinnerSelection = 0
+
     private fun addPlatformsListToRoom(spinnerResponseItem: PlatformsResponseItem){
         viewModelScope.launch(Dispatchers.IO) {
             gameStacheRepo.storePlatformsListToDb(spinnerResponseItem)


### PR DESCRIPTION
-Created three variables in exploreViewModel to keep track of the state of each spinner in ExploreFragment.kt

-When the user navigates into the individual game, favorites, or wishlist screen, the spinners maintain their previous selection.