### PR TITLE
Placing Current Gen Platforms at Top of Platform Spinner

### DIFF
--- a/app/src/main/java/com/example/gamestache/koin/KoinModule.kt
+++ b/app/src/main/java/com/example/gamestache/koin/KoinModule.kt
@@ -103,7 +103,7 @@ val gameStacheRepositoryModule = module {
 
 val exploreViewModelModule = module {
 
-    viewModel { ExploreViewModel(get()) }
+    viewModel { ExploreViewModel(get(), get()) }
 
 }
 

--- a/app/src/main/java/com/example/gamestache/repository/GameStacheRepository.kt
+++ b/app/src/main/java/com/example/gamestache/repository/GameStacheRepository.kt
@@ -30,9 +30,9 @@ class GameStacheRepository(
     private val favoritesAndWishlistDao: FavoritesAndWishlistDao
 ) {
 
-    fun getPlatformsListFromDb(): LiveData<List<GenericSpinnerItem>> = platformsResponseDao.getPlatformsListFromDb()
-    fun getGenresListFromDb(): LiveData<List<GenericSpinnerItem>> = genresResponseDao.getGenresListFromDb()
-    fun getGameModesListFromDb(): LiveData<List<GenericSpinnerItem>> = gameModesResponseDao.getGameModesListFromDb()
+    fun getPlatformsListFromDb(): LiveData<MutableList<GenericSpinnerItem>> = platformsResponseDao.getPlatformsListFromDb()
+    fun getGenresListFromDb(): LiveData<MutableList<GenericSpinnerItem>> = genresResponseDao.getGenresListFromDb()
+    fun getGameModesListFromDb(): LiveData<MutableList<GenericSpinnerItem>> = gameModesResponseDao.getGameModesListFromDb()
     fun checkIfGameIsInDb(gameID: Int): LiveData<Int> = individualGameDao.checkIfGameExistsInRoom(gameID)
     fun getIndividualGameDataFromDb(gameID: Int): LiveData<List<IndividualGameDataItem?>> = individualGameDao.getIndividualGameDataFromRoom(gameID)
     private fun getTwitchAuthFromDb(): TwitchAuthorization = twitchAuthorizationDao.getTwitchAuthFromDb()

--- a/app/src/main/java/com/example/gamestache/room/GameModesSpinnerDao.kt
+++ b/app/src/main/java/com/example/gamestache/room/GameModesSpinnerDao.kt
@@ -13,5 +13,5 @@ interface GameModesSpinnerDao {
 
     @Transaction
     @Query("SELECT * FROM game_modes_list_table ORDER BY name ASC")
-    fun getGameModesListFromDb(): LiveData<List<GenericSpinnerItem>>
+    fun getGameModesListFromDb(): LiveData<MutableList<GenericSpinnerItem>>
 }

--- a/app/src/main/java/com/example/gamestache/room/GenresSpinnerDao.kt
+++ b/app/src/main/java/com/example/gamestache/room/GenresSpinnerDao.kt
@@ -13,6 +13,6 @@ interface GenresSpinnerDao {
 
     @Transaction
     @Query("SELECT * FROM genres_list_table ORDER BY name ASC")
-    fun getGenresListFromDb(): LiveData<List<GenericSpinnerItem>>
+    fun getGenresListFromDb(): LiveData<MutableList<GenericSpinnerItem>>
 
 }

--- a/app/src/main/java/com/example/gamestache/room/PlatformSpinnerDao.kt
+++ b/app/src/main/java/com/example/gamestache/room/PlatformSpinnerDao.kt
@@ -13,6 +13,6 @@ interface PlatformSpinnerDao {
 
     @Transaction
     @Query("SELECT * FROM platforms_list_table ORDER BY name ASC")
-    fun getPlatformsListFromDb(): LiveData<List<GenericSpinnerItem>>
+    fun getPlatformsListFromDb(): LiveData<MutableList<GenericSpinnerItem>>
 
 }

--- a/app/src/main/java/com/example/gamestache/ui/explore/ExploreFragment.kt
+++ b/app/src/main/java/com/example/gamestache/ui/explore/ExploreFragment.kt
@@ -59,19 +59,20 @@ class ExploreFragment : Fragment() {
         exploreViewModel.getAuthToken(requireContext())
 
         exploreViewModel.currentPlatformListInDb.observe(viewLifecycleOwner, { spinnerListFromRoom ->
-            platformSpinner = platformSpinner?.let { initSpinners(it, spinnerListFromRoom, PLATFORM_SPINNER_PROMPT) }
+            platformSpinner = platformSpinner?.let { initSpinners(it, spinnerListFromRoom, PLATFORM_SPINNER_PROMPT, ExploreSpinners.PLATFORM_SPINNER
+            ) }
             platformSpinner?.let { setSpinnerOnClick(it, "platform") }
             platformSpinner?.setSelection(exploreViewModel.platformSpinnerSelection)
         })
 
         exploreViewModel.currentGenreListInDb.observe(viewLifecycleOwner, { spinnerListFromRoom ->
-            genreSpinner = genreSpinner?.let { initSpinners(it, spinnerListFromRoom, GENRE_SPINNER_PROMPT) }
+            genreSpinner = genreSpinner?.let { initSpinners(it, spinnerListFromRoom, GENRE_SPINNER_PROMPT, ExploreSpinners.GENRE_SPINNER) }
             genreSpinner?.let { setSpinnerOnClick(it, "genre") }
             genreSpinner?.setSelection(exploreViewModel.genreSpinnerSelection)
         })
 
         exploreViewModel.currentGameModesListInDb.observe(viewLifecycleOwner, { spinnerListFromRoom ->
-            gameModesSpinner = gameModesSpinner?.let { initSpinners(it, spinnerListFromRoom, GAME_MODES_SPINNER_PROMPT) }
+            gameModesSpinner = gameModesSpinner?.let { initSpinners(it, spinnerListFromRoom, GAME_MODES_SPINNER_PROMPT, ExploreSpinners.GAME_MODE_SPINNER) }
             gameModesSpinner?.let { setSpinnerOnClick(it, "gameMode") }
             gameModesSpinner?.setSelection(exploreViewModel.gameModesSpinnerSelection)
         })
@@ -163,7 +164,7 @@ class ExploreFragment : Fragment() {
 
         exploreViewModel.twitchAuthorization.value?.access_token?.let { twitchAccessToken ->
             if (isOnline(requireContext())) {
-                exploreViewModel.searchForGames(twitchAccessToken, searchRequestBody, requireContext(), resources)
+                exploreViewModel.searchForGames(twitchAccessToken, searchRequestBody, requireContext())
             } else {
                 Log.i(PERFORM_GAME_SEARCH_LOG_TAG, IS_OFFLINE_LOG_TEXT)
                 makeNoInternetToast(requireContext(), resources).show()
@@ -179,8 +180,8 @@ class ExploreFragment : Fragment() {
         inputMethodManager.hideSoftInputFromWindow(activity?.currentFocus?.windowToken, 0)
     }
 
-    private fun initSpinners(spinner: Spinner, spinnerListFromRoom: List<GenericSpinnerItem>, prompt: String): Spinner {
-        val spinnerListWithPrompt = exploreViewModel.addPromptToSpinnerList(spinnerListFromRoom, prompt)
+    private fun initSpinners(spinner: Spinner, spinnerListFromRoom: MutableList<GenericSpinnerItem>, prompt: String, spinnerType: ExploreSpinners): Spinner {
+        val spinnerListWithPrompt = exploreViewModel.addPromptToSpinnerList(spinnerListFromRoom, prompt, spinnerType)
         val customAdapter = SpinnerAdapter(requireContext(), spinnerListWithPrompt)
         spinner.adapter = customAdapter
         return spinner

--- a/app/src/main/java/com/example/gamestache/ui/explore/ExploreViewModel.kt
+++ b/app/src/main/java/com/example/gamestache/ui/explore/ExploreViewModel.kt
@@ -6,6 +6,7 @@ import android.util.Log
 import android.view.View.GONE
 import android.view.View.VISIBLE
 import androidx.lifecycle.*
+import com.example.gamestache.R
 import com.example.gamestache.isOnline
 import com.example.gamestache.makeNoInternetToast
 import com.example.gamestache.massageDataForListAdapter
@@ -25,7 +26,7 @@ import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
 import retrofit2.Response
 
-class ExploreViewModel(private val gameStacheRepo: GameStacheRepository) : ViewModel() {
+class ExploreViewModel(private val gameStacheRepo: GameStacheRepository, private val resources: Resources) : ViewModel() {
     val twitchAuthorization: MutableLiveData<TwitchAuthorization?> = MutableLiveData()
 
     private val gamesList: MutableLiveData<SearchResultsResponse> = MutableLiveData()
@@ -38,9 +39,9 @@ class ExploreViewModel(private val gameStacheRepo: GameStacheRepository) : ViewM
     val nameSearchText: MutableLiveData<String> = MutableLiveData("")
     val progressBarIsVisible: MutableLiveData<Boolean> = MutableLiveData(false)
 
-    val currentPlatformListInDb: LiveData<List<GenericSpinnerItem>> = gameStacheRepo.getPlatformsListFromDb()
-    val currentGenreListInDb: LiveData<List<GenericSpinnerItem>> = gameStacheRepo.getGenresListFromDb()
-    val currentGameModesListInDb: LiveData<List<GenericSpinnerItem>> = gameStacheRepo.getGameModesListFromDb()
+    val currentPlatformListInDb: LiveData<MutableList<GenericSpinnerItem>> = gameStacheRepo.getPlatformsListFromDb()
+    val currentGenreListInDb: LiveData<MutableList<GenericSpinnerItem>> = gameStacheRepo.getGenresListFromDb()
+    val currentGameModesListInDb: LiveData<MutableList<GenericSpinnerItem>> = gameStacheRepo.getGameModesListFromDb()
 
     var platformSpinnerSelection = 0
     var genreSpinnerSelection = 0
@@ -71,7 +72,7 @@ class ExploreViewModel(private val gameStacheRepo: GameStacheRepository) : ViewM
         }
     }
 
-    fun searchForGames(accessToken: String, gamesSearch: RequestBody, context: Context, resources: Resources) {
+    fun searchForGames(accessToken: String, gamesSearch: RequestBody, context: Context) {
         if (isOnline(context)) {
             viewModelScope.launch(Dispatchers.IO) {
                 progressBarIsVisible.postValue(true)
@@ -128,15 +129,38 @@ class ExploreViewModel(private val gameStacheRepo: GameStacheRepository) : ViewM
         }
     }
 
-    fun addPromptToSpinnerList(spinnerList: List<GenericSpinnerItem>?, spinnerPrompt: String): MutableList<String?> {
-        val list: MutableList<String?> = emptyList<String>().toMutableList()
-        list.add(spinnerPrompt)
-        if (spinnerList != null) {
+    fun addPromptToSpinnerList(spinnerList: MutableList<GenericSpinnerItem>?, spinnerPrompt: String, spinnerType: ExploreFragment.ExploreSpinners): MutableList<String?> {
+        var list: MutableList<String?> = mutableListOf()
+        if (spinnerType == ExploreFragment.ExploreSpinners.PLATFORM_SPINNER) {
+            list = putCurrentGenPlatformsAtBeginningOfList(spinnerList, list)
+        }
+        list.add(0, spinnerPrompt)
+
+        spinnerList?.let { spinnerList ->
             for (item in spinnerList) {
                 list.add(item.name)
             }
         }
         return list
+    }
+
+    private fun putCurrentGenPlatformsAtBeginningOfList(platformList: List<GenericSpinnerItem>?, reorderedList: MutableList<String?>): MutableList<String?> {
+        platformList?.let {
+            for (platform in platformList) {
+                when (platform.name) {
+                    resources.getString(R.string.android_platform_name) -> reorderedList.add(platform.name)
+                    resources.getString(R.string.iOS_platform_name) -> reorderedList.add(platform.name)
+                    resources.getString(R.string.linux_platform_name) -> reorderedList.add(platform.name)
+                    resources.getString(R.string.mac_platform_name) -> reorderedList.add(platform.name)
+                    resources.getString(R.string.nintendo_platform_name) -> reorderedList.add(platform.name)
+                    resources.getString(R.string.pc_platform_name) -> reorderedList.add(platform.name)
+                    resources.getString(R.string.playstation_platform_name) -> reorderedList.add(platform.name)
+                    resources.getString(R.string.xbox_platform_name) -> reorderedList.add(platform.name)
+                }
+            }
+        }
+
+        return reorderedList
     }
 
     fun searchText(): LiveData<RequestBody> =
@@ -189,3 +213,4 @@ class ExploreViewModel(private val gameStacheRepo: GameStacheRepository) : ViewM
         const val GAMES_SEARCH_LOG_TAG = "ExploreViewModel - Games Search"
     }
 }
+

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -60,5 +60,13 @@
     <string name="game_is_in_wishlist_text">Wishlist \u2713</string>
     <string name="no_games_in_wishlist_text_view">There are no games in your wishlist yet. Add some from the explore screen then come back.</string>
     <string name="no_internet_access_toast_text">No internet access. Check your internet connection and try again.</string>
+    <string name="android_platform_name">Android</string>
+    <string name="iOS_platform_name">iOS</string>
+    <string name="linux_platform_name">Linux</string>
+    <string name="mac_platform_name">Mac</string>
+    <string name="nintendo_platform_name">Nintendo Switch</string>
+    <string name="pc_platform_name">PC (Microsoft Windows)</string>
+    <string name="playstation_platform_name">PlayStation 5</string>
+    <string name="xbox_platform_name">Xbox Series X|S</string>
 
 </resources>


### PR DESCRIPTION
-Created a function to place the current gen platforms at the top of the platform spinner.

-The platforms are picked manually for a couple of reasons.
   1. New platforms are released quite infrequently.
   2. There isn't an easy way to identify the most recent platforms from the api. For example, the Nintendo Switch and PS5 belong to generation 8, and 9 respectively. While Android and iOS don't belong to a generation at all.